### PR TITLE
Fix reference expansion

### DIFF
--- a/src/integrant/core.clj
+++ b/src/integrant/core.clj
@@ -75,8 +75,13 @@
 (defn- sort-keys [ks m]
   (sort (dep/topo-comparator (dependency-graph m)) ks))
 
+(defn- lookup-refs
+  "Replace all refs in subconfig with referenced value from config."
+  ([config subconfig]
+   (walk/postwalk #(if (ref? %) (config (:key %) %) %) subconfig)))
+
 (defn- update-key [m k]
-  (-> m (update k (partial init-key k)) (expand-1 k)))
+  (-> m (update k (comp (partial init-key k) (partial lookup-refs m)))))
 
 (defn init
   "Turn a config map into an system map. Keys are traversed in dependency


### PR DESCRIPTION
To expand a key, the current implementation walks the whole config, including previously expanded parts, which can have undesired effects (e.g., if the expanded config contains large data structures or other references).

The new implementation would look up references in the part of the config for the key that is to be "initialized".