### PR TITLE
Add run! and reverse-run! functions

### DIFF
--- a/test/integrant/core_test.cljc
+++ b/test/integrant/core_test.cljc
@@ -66,3 +66,27 @@
          (build-log
           {:a (ig/ref :b)
            :b 1}))))
+
+(defn test-log [f m]
+  (let [log (atom [])]
+    [(f m
+        (keys m)
+        (fn [k v]
+          (last (swap! log conj [:test k v]))))
+     @log]))
+
+(deftest run-test
+  (let [config {:a (ig/ref :b), :b 1}
+        [system _] (build-log config)]
+    (is
+     (= [nil
+         [[:test :b [:build :b 1]]
+          [:test :a [:build :a [:build :b 1]]]]]
+        (test-log ig/run! system)))
+    (is
+     (= [nil
+         [[:test :a [:build :a [:build :b 1]]]
+          [:test :b [:build :b 1]]]]
+        (test-log ig/reverse-run! system)))
+    [(test-log ig/run! system)
+     (test-log ig/reverse-run! system)]))


### PR DESCRIPTION
Add a function to update a system in reverse dependency order by applying a function f on each key value pair. This function complements the 'build' function and could be used for example to suspend a system.