### PR TITLE
Implement ClojureScript support

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,4 +4,33 @@
   :license {:name "The MIT License"
             :url "http://opensource.org/licenses/MIT"}
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [com.stuartsierra/dependency "0.2.0"]])
+                 [com.stuartsierra/dependency "0.2.0"]]
+  :profiles {:dev {:dependencies [[org.clojure/clojurescript "1.7.228"]]}}
+  :plugins [[lein-doo "0.1.7"]]
+  :cljsbuild
+  {:builds [{:id "phantom-test"
+             :source-paths ["src" "test"]
+             :compiler {:output-to  "target/cljs/phantom-test/integrant-test.js"
+                        :output-dir "target/cljs/phantom-test/out"
+                        :main integrant.test-runner
+                        :optimizations :none}}
+            {:id "nashorn-test"
+             :source-paths ["src" "test"]
+             :compiler {:output-to  "target/cljs/nashorn-test/integrant-test.js"
+                        :output-dir "target/cljs/nashorn-test/out"
+                        :main integrant.test-runner
+                        ;; nashorn apparently doesn't support :none or :whitespace (??!)
+                        :optimizations :simple}}
+            {:id "node-test"
+             :source-paths ["src" "test"]
+             :compiler {:target :nodejs
+                        :output-to  "target/cljs/node-test/integrant-test.js"
+                        :output-dir "target/cljs/node-test/out"
+                        :main integrant.test-runner
+                        :optimizations :none}}]}
+  :aliases {"phantom-test" ["doo" "phantom" "phantom-test" "once"]
+            "nashorn-test" ["doo" "nashorn" "nashorn-test" "once"]
+            "node-test"    ["doo" "node" "node-test" "once"]
+            "cljs-test"    ["do" ["phantom-test"] ["nashorn-test"] ["node-test"]]
+            "all-tests"    ["do" ["test"] ["cljs-test"]]})
+

--- a/src/integrant/core.cljc
+++ b/src/integrant/core.cljc
@@ -1,7 +1,7 @@
 (ns integrant.core
   (:refer-clojure :exclude [ref read-string])
   (:require [com.stuartsierra.dependency :as dep]
-            [clojure.edn :as edn]
+    #?(:clj [clojure.edn :as edn])
             [clojure.walk :as walk]
             [clojure.string :as str]))
 
@@ -33,15 +33,16 @@
              (dep/graph)
              config))
 
-(defn read-string
-  "Read a config from a string of edn. Refs may be denotied by tagging keywords
-  with #ref."
-  ([s]
-   (read-string {:eof nil} s))
-  ([opts s]
-   (let [readers (merge {'ref ref} (:readers opts {}))]
-     (edn/read-string (assoc opts :readers readers) s))))
-
+#?(:clj
+   (defn read-string
+    "Read a config from a string of edn. Refs may be denotied by tagging keywords
+     with #ref."
+     ([s]
+      (read-string {:eof nil} s))
+     ([opts s]
+      (let [readers (merge {'ref ref} (:readers opts {}))]
+        (edn/read-string (assoc opts :readers readers) s)))))
+ 
 (defn- expand-key [config value]
   (walk/postwalk #(if (ref? %) (config (:key %)) %) value))
 

--- a/test/integrant/core_test.cljc
+++ b/test/integrant/core_test.cljc
@@ -1,7 +1,7 @@
 (ns integrant.core-test
-  (:require [clojure.test :refer :all]
-            [integrant.core :as ig]))
-
+  (:require [integrant.core :as ig]
+   #?(:clj  [clojure.test :refer :all]
+      :cljs [cljs.test :refer-macros [deftest is]])))
 (def log (atom []))
 
 (defmethod ig/init-key :default [k v]
@@ -20,11 +20,12 @@
   (is (= (ig/expand {::a (ig/ref ::b), ::b (ig/ref ::c), ::c 2})
          {::a 2, ::b 2, ::c 2})))
 
-(deftest read-string-test
-  (is (= (ig/read-string "{:foo/a #ref :foo/b, :foo/b 1}")
-         {:foo/a (ig/ref :foo/b), :foo/b 1}))
-  (is (= (ig/read-string {:readers {'var find-var}} "{:foo/a #var clojure.core/+}")
-         {:foo/a #'+})))
+#?(:clj
+   (deftest read-string-test
+     (is (= (ig/read-string "{:foo/a #ref :foo/b, :foo/b 1}")
+            {:foo/a (ig/ref :foo/b), :foo/b 1}))
+     (is (= (ig/read-string {:readers {'var find-var}} "{:foo/a #var clojure.core/+}")
+            {:foo/a #'+}))))
 
 (deftest init-test
   (reset! log [])
@@ -43,6 +44,7 @@
                  [:halt ::b [1]]]))))
 
 (deftest missing-ref-test
-  (is (thrown-with-msg? clojure.lang.ExceptionInfo
+  (is (thrown-with-msg? #?(:clj  clojure.lang.ExceptionInfo
+                           :cljs cljs.core.ExceptionInfo)
                         #"Missing definitions for refs: :integrant.core-test/b"
                         (ig/init {::a (ig/ref ::b)}))))

--- a/test/integrant/test_runner.cljs
+++ b/test/integrant/test_runner.cljs
@@ -1,0 +1,5 @@
+(ns integrant.test-runner
+  (:require [doo.runner :refer-macros [doo-tests]]
+            [integrant.core-test]))
+
+(doo-tests 'integrant.core-test)


### PR DESCRIPTION
Since you're requiring clojure 1.7, we can take advantage of cljc files, which I've done to add clojurescript support.

Tests are configured for phantomjs, nodejs and nashorn, all pass and there are some convenience aliases.

I had to make `read-string` clj only because i'm not quite sure what to do about it in cljs-land, any thoughts?