### PR TITLE
Resolve derived refs for dependency-graph

### DIFF
--- a/src/integrant/core.cljc
+++ b/src/integrant/core.cljc
@@ -24,10 +24,38 @@
     (ref? v)  (list (:key v))
     (coll? v) (mapcat find-refs v)))
 
+(defn- ambiguous-key-exception [config key matching-keys]
+  (ex-info (str "Ambiguous key: " key ". Found multiple candidates: "
+                (str/join ", " (sort matching-keys)))
+           {:reason ::ambiguous-key
+            :config config
+            :key    key
+            :matching-keys matching-keys}))
+
+(defn find-derived
+  "Return a seq of all entries in a map, m, where the key is derived from the
+  keyword, k. If there are no matching keys, nil is returned."
+  [m k]
+  (seq (filter #(isa? (key %) k) m)))
+
+(defn find-derived-1
+  "Return the map entry in a map, m, where the key is derived from the keyword,
+  k. If there are no matching keys, nil is returned. If there is more than one
+  matching key, an ambiguous key exception is raised."
+  [m k]
+  (let [kvs (find-derived m k)]
+    (when (next kvs)
+      (throw (ambiguous-key-exception m k (map key kvs))))
+    (first kvs)))
+
+(defn- find-derived-refs [config v]
+  (map #(key (find-derived-1 config %)) (find-refs v)))
+
 (defn dependency-graph
-  "Return a dependency graph of all the refs in a config."
+  "Return a dependency graph of all the refs in a config. Resolve derived
+  dependencies."
   [config]
-  (reduce-kv (fn [g k v] (reduce #(dep/depend %1 k %2) g (find-refs v)))
+  (reduce-kv (fn [g k v] (reduce #(dep/depend %1 k %2) g (find-derived-refs config v)))
              (dep/graph)
              config))
 
@@ -65,35 +93,11 @@
                  (distinct)
                  (keep try-require)))))
 
-(defn- ambiguous-key-exception [config key matching-keys]
-  (ex-info (str "Ambiguous key: " key ". Found multiple candidates: "
-                (str/join ", " (sort matching-keys)))
-           {:reason ::ambiguous-key
-            :config config
-            :key    key
-            :matching-keys matching-keys}))
-
 (defn- missing-refs-exception [config refs]
   (ex-info (str "Missing definitions for refs: " (str/join ", " (sort refs)))
            {:reason ::missing-refs
             :config config
             :missing-refs refs}))
-
-(defn find-derived
-  "Return a seq of all entries in a map, m, where the key is derived from the
-  keyword, k. If there are no matching keys, nil is returned."
-  [m k]
-  (seq (filter #(isa? (key %) k) m)))
-
-(defn find-derived-1
-  "Return the map entry in a map, m, where the key is derived from the keyword,
-  k. If there are no matching keys, nil is returned. If there is more than one
-  matching key, an ambiguous key exception is raised."
-  [m k]
-  (let [kvs (find-derived m k)]
-    (when (next kvs)
-      (throw (ambiguous-key-exception m k (map key kvs))))
-    (first kvs)))
 
 (defn- ambiguous-refs [config]
   (filter #(next (find-derived config %)) (find-refs config)))

--- a/test/integrant/core_test.cljc
+++ b/test/integrant/core_test.cljc
@@ -1,7 +1,8 @@
 (ns integrant.core-test
   (:require [integrant.core :as ig]
    #?(:clj  [clojure.test :refer :all]
-      :cljs [cljs.test :refer-macros [deftest is testing]])))
+      :cljs [cljs.test :refer-macros [deftest is testing]])
+            [com.stuartsierra.dependency :as dep]))
 
 (def log (atom []))
 
@@ -53,6 +54,9 @@
 
 (derive ::p ::pp)
 (derive ::pp ::ppp)
+
+(deftest dependency-graph-test
+  (is (dep/depends? (ig/dependency-graph {::a (ig/ref ::ppp) ::p "b"}) ::a ::p)))
 
 (deftest find-derived-test
   (is (nil? (ig/find-derived-1 {} ::p)))


### PR DESCRIPTION
Resolve derived refs in the function `dependency-graph` to ensure a correct topological order (say for `build`). 