### PR TITLE
Improve 'load-namespaces' to handle derived keywords

### DIFF
--- a/src/integrant/core.cljc
+++ b/src/integrant/core.cljc
@@ -85,11 +85,12 @@
       (let [readers (merge {'ref ref} (:readers opts {}))]
         (edn/read-string (assoc opts :readers readers) s)))))
 
-#?(:clj
+#?(:clj 
    (defn- keyword->namespaces [kw]
-     (if-let [ns (namespace kw)]
-       [(symbol ns)
-        (symbol (str ns "." (name kw)))])))
+     (let [kw (if (vector? kw) (first kw) kw)]
+       (if-let [ns (namespace kw)]
+         [(symbol ns)
+          (symbol (str ns "." (name kw)))]))))
 
 #?(:clj
    (defn- try-require [sym]


### PR DESCRIPTION
I am using integrant and found very useful to load-namespaces, but when derived keyword are present in the configuration didn't work so I added that functionality, hope you like it.