### PR TITLE
Add integrant.spec namespace

### DIFF
--- a/src/integrant/spec.clj
+++ b/src/integrant/spec.clj
@@ -1,0 +1,158 @@
+(ns integrant.spec
+
+  "Utilities for clojure.spec
+   
+   As far as validation is concerned, the user can use ::configuration. Given a configuration map,
+   this spec validates every key-value by using the key to find a spec in the global registry.
+   It takes into account derived and composite keys. It also checks if there are any ambiguous keys."
+
+  (:refer-clojure :exclude [ref])
+  (:require [clojure.spec.alpha :as s]
+            [integrant.core     :as ig]))
+
+
+
+
+;;;;;;;;;; API
+
+
+(defn ref
+
+  "Produces a spec for an integrant reference."
+
+  [key]
+
+  (s/and ig/reflike?
+         #(ig/derived-from? (ig/ref-key %)
+                            key)))
+
+
+
+
+(defn get-spec
+
+  "Finds the spec of a simple, derived or composite key."
+
+  [key]
+
+  (if (vector? key)
+    (some s/get-spec
+          (reverse key))
+    (or (s/get-spec key)
+        (some s/get-spec
+              (parents key)))))
+
+
+
+
+(defn unambiguous-refs?
+
+  "Given `config-map`, are all the refs in `value` unambiguous ?"
+
+  [config-map value]
+
+  (not (some (fn ambiguous? [ref]
+               (next (ig/find-derived config-map
+                                      (ig/ref-key ref))))
+             (filter ig/ref?
+                     (tree-seq coll?
+                               seq
+                               value)))))
+
+
+
+
+;;;;;;;;;; Private
+
+
+(defn- -always-true
+
+  "Always returns true."
+
+  [_]
+
+  true)
+
+
+
+
+(defn- -generated
+
+  "For multi-specs, always returns the generated values unchanged."
+
+  [generated _tag]
+
+  generated)
+
+
+
+
+(defmulti ^:private -key-value
+
+  "Produces a spec for [key value]."
+
+  first
+
+  :default ::default)
+
+
+
+
+(defmethod -key-value ::default
+
+  [[k]]
+
+  (s/tuple -always-true
+           (or (get-spec k)
+               any?)))
+
+
+
+
+(defmulti ^:private -unambiguous-refs
+
+  "Given a configuration map, returns a spec testing of the refs in each value of a map are unambiguous."
+
+  identity
+
+  :default ::default)
+
+
+
+
+(defmethod -unambiguous-refs ::default
+
+  [config-map]
+
+  (s/map-of -always-true
+            #(unambiguous-refs? config-map
+                                %)))
+
+
+
+
+;;;;;;;;;; Specs
+
+
+(s/def ::key-value
+
+  (s/multi-spec -key-value
+                -generated))
+
+
+(s/def ::key-values
+
+  (s/coll-of ::key-value))
+
+
+(s/def ::unambiguous-refs
+
+  (s/multi-spec -unambiguous-refs
+                -generated))
+
+
+(s/def ::configuration
+
+  (s/and map?
+         ::key-values
+         ::unambiguous-refs))


### PR DESCRIPTION
Sorry for the delay ! This pull request is related to issue #32 for adding the 'integrant.spec' namespace. My solution is slightly different, the ::ig.spec/configuration spec replaces your idea of `ig.spec/derived-keys` as there is no need for a function, but the goal is the same. In order to work well enough with `s/explain`, I used `s/multi-spec` in a bit of an unconventional way. If you like it, I can write tests. For the time being, let's say it's "repl proven".

This namespace aims to provide utilities for clojure.spec, specially
regarding validation of configuration maps.

Notably :

  - `integrant.spec/ref` creates specs for refs.
  - :integrant.spec/configuration validates a configuration map by
  finding the spec for every key in the global registry. It takes into
  account derived and composite keys. Also, it checks for ambiguous
  refs.