### PR TITLE
Throw more informative errors when composite-keyword is missing namespace

### DIFF
--- a/src/integrant/core.cljc
+++ b/src/integrant/core.cljc
@@ -13,10 +13,13 @@
 (defrecord Ref    [key] RefLike (ref-key [_] key))
 (defrecord RefSet [key] RefLike (ref-key [_] key))
 
+(defn- composite-key? [keys]
+  (and (vector? keys) (every? qualified-keyword? keys)))
+
 (defn valid-config-key?
-  "Returns true if the key is a keyword or a vector of keywords."
+  "Returns true if the key is a keyword or valid composite key."
   [key]
-  (or (keyword? key) (and (vector? key) (every? keyword? key))))
+  (or (keyword? key) (composite-key? key)))
 
 (defn ref
   "Create a reference to a top-level key in a config map."
@@ -193,6 +196,15 @@
        (map ref-key)
        (remove #(find-derived config %))))
 
+(defn- invalid-composite-keys [config]
+  (->> (keys config) (filter vector?) (remove composite-key?)))
+
+(defn- invalid-composite-key-exception [config key]
+  (ex-info (str "Invalid composite key: " key ". Every keyword must be namespaced.")
+           {:reason ::invalid-composite-key
+            :config config
+            :key key}))
+
 (defn- resolve-ref [config ref]
   (val (first (find-derived config (ref-key ref)))))
 
@@ -293,6 +305,8 @@
    {:pre [(map? config)]}
    (let [relevant-keys   (dependent-keys config keys)
          relevant-config (select-keys config relevant-keys)]
+     (when-let [invalid-key (first (invalid-composite-keys config))]
+       (throw (invalid-composite-key-exception config invalid-key)))
      (when-let [ref (first (ambiguous-refs relevant-config))]
        (throw (ambiguous-key-exception config ref (map key (find-derived config ref)))))
      (when-let [refs (seq (missing-refs relevant-config))]

--- a/test/integrant/core_test.cljc
+++ b/test/integrant/core_test.cljc
@@ -251,6 +251,13 @@
                        [:init [::b ::c ::e] 1]
                        [:init ::a [1]]])))))
 
+  (testing "with failing composite refs"
+    (reset! log [])
+    (is (thrown-with-msg?
+          #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core.ExceptionInfo)
+          #"^Invalid composite key: \[:integrant.core-test/a :b\]. Every keyword must be namespaced.$"
+          (ig/init {[::a :b] :anything}))))
+
   (testing "with refsets"
     (reset! log [])
     (let [m (ig/init {::a (ig/refset ::ppp), ::p 1, ::pp 2})]
@@ -469,7 +476,7 @@
                            ::error-halt (ig/ref ::a)
                            ::b (ig/ref ::error-halt)
                            ::c (ig/ref ::b)})
-          ex     (try (ig/halt! system) 
+          ex     (try (ig/halt! system)
                       (catch #?(:clj Throwable :cljs :default) t t))]
       (is (some? ex))
       (is (= (#?(:clj .getMessage :cljs ex-message) ex)


### PR DESCRIPTION
I've been using Integrant extensively building out a UI framework and we bumped into a hard to diagnose error with composite keywords.

In short, if you accidentally use a simple keyword (`:foo`) instead of a namespace-qualified one (`:my.ns/foo`) inside a composite keyword you will see the following exception. 

    Assert failed: (namespace parent)

I propose adding a `ensure-kw-namespaces!` check to `composite-keyword` that will raise an informative exception if an invalid keyword is encountered.

Let me know what you think.