### PR TITLE
Don't halt keys that are dependencies of resumed keys

### DIFF
--- a/src/integrant/core.cljc
+++ b/src/integrant/core.cljc
@@ -414,9 +414,10 @@
 (defn- missing-keys [system ks]
   (remove (set ks) (keys system)))
 
-(defn- halt-missing-keys! [system keys]
-  (let [graph (-> system meta ::origin dependency-graph)]
-    (doseq [k (sort (key-comparator graph) (missing-keys system keys))]
+(defn- halt-missing-keys! [config system keys]
+  (let [graph        (-> system meta ::origin dependency-graph)
+        missing-keys (missing-keys system (dependent-keys config keys))]
+    (doseq [k (sort (key-comparator graph) missing-keys)]
       (halt-key! k (system k)))))
 
 (defn resume
@@ -428,7 +429,7 @@
    (resume config system (keys config)))
   ([config system keys]
    {:pre [(map? config) (map? system) (some-> system meta ::origin)]}
-   (halt-missing-keys! system keys)
+   (halt-missing-keys! config system keys)
    (build config keys (fn [k v]
                         (if (contains? system k)
                           (resume-key k v (-> system meta ::build (get k)) (system k))

--- a/test/integrant/core_test.cljc
+++ b/test/integrant/core_test.cljc
@@ -403,7 +403,21 @@
                    [:suspend ::a [:x]]
                    [:suspend [::b ::x] :x]
                    [:resume [::b ::x] 1 1 :x]
-                   [:resume ::a :rx :x [:x]]])))))
+                   [:resume ::a :rx :x [:x]]]))))
+
+  (testing "resume key with dependencies"
+    (reset! log [])
+    (let [c  {::a {:b (ig/ref ::b)}, ::b 1}
+          m  (ig/init c [::a])
+          _  (ig/suspend! m)
+          m' (ig/resume c m [::a])]
+      (is (= @log
+             [[:init ::b 1]
+              [:init ::a {:b [1]}]
+              [:suspend ::a [{:b [1]}]]
+              [:suspend ::b [1]]
+              [:resume ::b 1 1 [1]]
+              [:resume ::a {:b [1]} {:b [1]} [{:b [1]}]]])))))
 
 (deftest invalid-configs-test
   (testing "ambiguous refs"


### PR DESCRIPTION
Make `halt-missing-keys!` aware of dependent keys, otherwise dependent keys that
are meant to be resumed will be treated as missing instead, and halted before
being resumed.

Closes #40 .