### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ is raised if it fails.
 
 Here's how our two example keys would be specced out:
 
-```clojre
+```clojure
 (require '[clojure.spec.alpha :as s])
 
 (s/def ::port pos-int?)


### PR DESCRIPTION
Changed `clojre` to `clojure` -- so that the syntax highlighting shows.

Thanks for the work on Integrant!