### PR TITLE
Make resolve-ref public

### DIFF
--- a/src/integrant/core.cljc
+++ b/src/integrant/core.cljc
@@ -212,7 +212,7 @@
             :config config
             :key key}))
 
-(defn- resolve-ref [config resolvef ref]
+(defn resolve-ref [config resolvef ref]
   (let [[k v] (first (find-derived config (ref-key ref)))]
     (resolvef k v)))
 


### PR DESCRIPTION
I think this would be convenient when working at the repl when one is working several component instances derived from the same ig/init-key.

Example:

Say we have 2 db instances in our config

```
[:duct.database.sql/hikaricp :db/-1] {...}
[:duct.database.sql/hikaricp :db/-2] {...}
```

We would grab the instance at the repl like this:

`(get integrant.repl.state/system [:duct.database.sql/hikaricp :db/-1] )`

Making resolve-ref public would allow save some typing the longer the init-key is.
`(resolve-ref integrant.repl.state/system (ig/ref :db/-1))`

Or perhaps add a convenience function in integrant.repl that allows this?