### PR TITLE
Add support for Spec Alternatives

### DIFF
--- a/src/integrant/core.cljc
+++ b/src/integrant/core.cljc
@@ -404,7 +404,15 @@
             :spec     spec
             :explain  ed}))
 
-(defn- assert-pre-init-spec [system key value]
+(defmulti assert-pre-init-spec
+  "Function that is used to assert that the data used to initialize the key matches the
+  data returned by `pre-init-spec`.
+
+  Defaults to asserting with `spec` but is configurable to allow alternative schema engines."
+  {:arglists '([system key value])}
+  (fn [_ _ _] :default))
+
+(defmethod assert-pre-init-spec :default [system key value]
   (when-let [spec (pre-init-spec key)]
     (when-not (s/valid? spec value)
       (throw (spec-exception system key value spec (s/explain-data spec value))))))


### PR DESCRIPTION
This commit introduces pluggable support for spec alternatives by introducing a configurable multi-method for `ig/assert-pre-init-spec`.

The `:default` implementation is to still use `spec` - but an advanced user can configure this to do whatever.

Although a user can already specify a custom pre-init validator using `build` many tools (eg. `integrant.repl`) call `ig/init` directly. This allows a user to get the same functionality without requiring them to rewrite everything from scratch.

One consideration is whether we should actually dispatch on anything for the multi-method or only ever use `:default`. I can't personally imagine a system needing to dispatch off of `system`, `key` or `value`, but let me know if you'd like it changed.