### PR TITLE
feat: add basic deps.edn

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,5 @@
+{:paths   ["src"]
+ :deps    {org.clojure/clojure    {:mvn/version "1.9.0"}
+           weavejester/dependency {:mvn/version "0.2.1"}}
+ :aliases {:dev  {:extra-deps {org.clojure/clojurescript {:mvn/version "1.10.597"}}}
+           :test {:extra-paths ["test"]}}}


### PR DESCRIPTION
This enables tools.deps users to use any commit for unreleased versions, fixing https://github.com/weavejester/integrant/issues/61
Might want to consider having `deps.edn` as the only source of deps instead of leiningen, but this should be enough for now.