### PR TITLE
Add a human understandable error message for ig/ref, and ig/refset

### DIFF
--- a/src/integrant/core.cljc
+++ b/src/integrant/core.cljc
@@ -13,6 +13,11 @@
 (defrecord Ref    [key] RefLike (ref-key [_] key))
 (defrecord RefSet [key] RefLike (ref-key [_] key))
 
+(defn- invalid-ref-exception [ref]
+  (ex-info (str "Invalid reference: " ref ". Must be a qualified keyword or a "
+                "vector of qualified keywords.")
+           {:reason ::invalid-ref, :ref ref}))
+
 (defn- composite-key? [keys]
   (and (vector? keys) (every? qualified-keyword? keys)))
 
@@ -24,13 +29,15 @@
 (defn ref
   "Create a reference to a top-level key in a config map."
   [key]
-  {:pre [(valid-config-key? key)]}
+  (when-not (valid-config-key? key)
+    (throw (invalid-ref-exception key)))
   (->Ref key))
 
 (defn refset
   "Create a set of references to all matching top-level keys in a config map."
   [key]
-  {:pre [(valid-config-key? key)]}
+  (when-not (valid-config-key? key)
+    (throw (invalid-ref-exception key)))
   (->RefSet key))
 
 (defn ref?


### PR DESCRIPTION
## Problem

Currently when you write an invalid reference key you get a very cryptic message. This is especially cumbersome to new users of Integrant, since you might not know what a valid key is. You do get a stacktrace to the invalid key, but I believe this should be easier to figure out.

![Screen Shot 2020-01-06 at 22 14 01](https://user-images.githubusercontent.com/629436/71849268-ef575e80-30d1-11ea-9031-5484ef21f545.png)

## Solution

Add a custom error message to the `:pre` condition. I'm not sure if this is the correct solution but this is the desired result. Note that the stacktrace location (in this case `config.cljs:34`) is still available.

![Screen Shot 2020-01-06 at 22 14 31](https://user-images.githubusercontent.com/629436/71849455-64c32f00-30d2-11ea-8d9c-dbde625131ca.png)

