### PR TITLE
Feature/add doc key multimethod

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,6 +491,28 @@ This will attempt to load the namespace `foo.component` and also
 `foo.component.bar`. A list of all successfully loaded namespaces will
 be returned from the function. Missing namespaces are ignored.
 
+## Documenting your keys
+
+You can use the `doc-key` multimethod to add a docstring to your key. This has
+no direct effect on your system and is generally useful for generating
+documentation.
+
+
+```clojure
+(defmethod ig/doc-key :handler/greet-all [_]
+  "An HTTP handler that responds with a greeting to all `:names'
+
+  | key      | description                            |
+  |  --------|----------------------------------------|
+  | `:names` | A list of string names ; default: `[]` |
+
+  Example:
+  ```edn
+  {:handler/greet-all {:names #ig/refset :const/name}
+  :const.name/alice   {:name \"Alice\"}
+  :const.name/bob     {:name \"Bob\"}}
+  ```")
+```
 ## Reloaded workflow
 
 See [Integrant-REPL](https://github.com/weavejester/integrant-repl) to 

--- a/src/integrant/core.cljc
+++ b/src/integrant/core.cljc
@@ -326,6 +326,14 @@
              (with-meta {} {::origin config})
              (map (fn [k] [k (config k)]) relevant-keys)))))
 
+(defmulti doc-key
+  "Add a docstring to a key. This has no direct effect on your system and is
+  generally useful for generating documentation."
+  {:arglists '([key])}
+  (fn [key] (normalize-key key)))
+
+(defmethod doc-key :default [_] nil)
+
 (defmulti resolve-key
   "Return a value to substitute for a reference prior to initiation. By default
   the value of the key is returned unaltered. This can be used to hide


### PR DESCRIPTION
## Problem
I'm currently working on a library that heavily uses Integrant and defining many keys that can be used by the end-user. It would be nice if there was a way to programmatically document these keys, for the purpose of generating documentation.

## Solution
Define a new multimethod, called `doc-key`. This would be consistent of the current `*-key` naming scheme. It's entirely up to the end-user of Integrant how to make use of this. 

The benefit of this solution is that library creators will have a consistent way of writing documentation. This would be a nice addition to `duct` libraries, for example being able to write `(ig/doc-key :duct.migrator/ragtime)` in the REPL and getting a docstring could be very useful. I _often_ struggle with figuring out what options a key accepts, resulting in having to dive into the source code.

## Other additions

Maybe we can somehow also incorporate the `pre-init-spec` multimethod with the `doc-key` string. Not sure how we would automatically do that though.

What's your opinion on this feature?