### PR TITLE
Add ClojureScript support for read-string

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,8 @@
             :url "http://opensource.org/licenses/MIT"}
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [weavejester/dependency "0.2.1"]]
-  :profiles {:dev {:dependencies [[org.clojure/clojurescript "1.10.597"]]}}
+  :profiles {:provided {:dependencies [[org.clojure/clojurescript "1.10.597"]
+                                       [org.clojure/tools.reader "1.3.2"]]}}
   :plugins [[lein-codox "0.10.4"]
             [lein-doo "0.1.7"]]
   :codox

--- a/src/integrant/core.cljc
+++ b/src/integrant/core.cljc
@@ -1,6 +1,7 @@
 (ns integrant.core
   (:refer-clojure :exclude [ref read-string run!])
-  (:require #?(:clj [clojure.edn :as edn])
+  (:require #?(:clj  [clojure.edn :as edn]
+               :cljs [clojure.tools.reader.edn :as edn])
             [clojure.walk :as walk]
             [clojure.set :as set]
             [clojure.spec.alpha :as s]
@@ -141,18 +142,16 @@
 (defn- reverse-dependent-keys [config keys]
   (reverse (find-keys config keys dep/transitive-dependents-set)))
 
-#?(:clj
-   (def ^:private default-readers {'ig/ref ref, 'ig/refset refset}))
+(def ^:private default-readers {'ig/ref ref, 'ig/refset refset})
 
-#?(:clj
-   (defn read-string
-    "Read a config from a string of edn. Refs may be denotied by tagging keywords
-     with #ig/ref."
-     ([s]
-      (read-string {:eof nil} s))
-     ([opts s]
-      (let [readers (merge default-readers (:readers opts {}))]
-        (edn/read-string (assoc opts :readers readers) s)))))
+(defn read-string
+  "Read a config from a string of edn. Refs may be denotied by tagging keywords
+  with #ig/ref."
+  ([s]
+   (read-string {:eof nil} s))
+  ([opts s]
+   (let [readers (merge default-readers (:readers opts {}))]
+     (edn/read-string (assoc opts :readers readers) s))))
 
 #?(:clj
    (defn- keyword->namespaces [kw]


### PR DESCRIPTION
# Problem
`read-string` is currently not supported for ClojureScript

# Solution
Add `org.clojure/tools.reader` as a provided dependency in order to use `edn/read-string` in ClojureScript.

Fixes https://github.com/weavejester/integrant/issues/73