### PR TITLE
Add mandatory/all methods to RefLike protocol

### DIFF
--- a/src/integrant/core.cljc
+++ b/src/integrant/core.cljc
@@ -10,6 +10,8 @@
 
 (defprotocol RefLike
   (ref-key [r] "Return the key of the reference.")
+  (ref-mandatory-keys [r] "Returns the mandatory keys.")
+  (ref-all-keys [r] "Returns the mandatory and optional keys.")
   (ref-resolve [r config resolvef] "Return the resolved value."))
 
 (defonce
@@ -63,6 +65,8 @@
 (defrecord Ref [key]
   RefLike
   (ref-key [_] key)
+  (ref-mandatory-keys [_] #{key})
+  (ref-all-keys [_] #{key})
   (ref-resolve [_ config resolvef]
     (let [[k v] (first (find-derived config key))]
       (resolvef k v))))
@@ -70,6 +74,8 @@
 (defrecord RefSet [key]
   RefLike
   (ref-key [_] key)
+  (ref-mandatory-keys [_] #{})
+  (ref-all-keys [_] #{key})
   (ref-resolve [_ config resolvef]
     (set (for [[k v] (find-derived config key)]
            (resolvef k v)))))
@@ -124,9 +130,9 @@
       (throw (ambiguous-key-exception m k (map key kvs))))
     (first kvs)))
 
-(defn- find-derived-refs [config v include-refsets?]
-  (->> (depth-search (if include-refsets? reflike? ref?) v)
-       (map ref-key)
+(defn- find-derived-refs [config v optional-deps?]
+  (->> (depth-search reflike? v)
+       (mapcat (if optional-deps? ref-all-keys ref-mandatory-keys))
        (mapcat #(map key (find-derived config %)))))
 
 (defn dependency-graph

--- a/src/integrant/core.cljc
+++ b/src/integrant/core.cljc
@@ -133,13 +133,13 @@
   "Return a dependency graph of all the refs and refsets in a config. Resolves
   derived dependencies. Takes the following options:
 
-  `:include-refsets?`
-  : whether to include refsets in the dependency graph (defaults to true)"
+  `:optional-deps?`
+  : whether to include optional deps in the dependency graph (defaults to true)"
   ([config]
    (dependency-graph config {}))
-  ([config {:keys [include-refsets?] :or {include-refsets? true}}]
+  ([config {:keys [optional-deps?] :or {optional-deps? true}}]
    (letfn [(find-refs [v]
-             (find-derived-refs config v include-refsets?))]
+             (find-derived-refs config v optional-deps?))]
      (reduce-kv (fn [g k v] (reduce #(dep/depend %1 k %2) g (find-refs v)))
                 (dep/graph)
                 config))))
@@ -152,7 +152,7 @@
   (dep/topo-comparator #(compare (str %1) (str %2)) graph))
 
 (defn- find-keys [config keys f]
-  (let [graph  (dependency-graph config {:include-refsets? false})
+  (let [graph  (dependency-graph config {:optional-deps? false})
         keyset (set (mapcat #(map key (find-derived config %)) keys))]
     (->> (f graph keyset)
          (set/union keyset)

--- a/test/integrant/core_test.cljc
+++ b/test/integrant/core_test.cljc
@@ -162,7 +162,7 @@
         (is (dep/depends? g ::b ::pp))))
 
     (testing "graph without refsets"
-      (let [g (ig/dependency-graph m {:include-refsets? false})]
+      (let [g (ig/dependency-graph m {:optional-deps? false})]
         (is (dep/depends? g ::a ::p))
         (is (not (dep/depends? g ::b ::p)))
         (is (not (dep/depends? g ::b ::pp)))))))


### PR DESCRIPTION
As per #77.
I also rebased on master, some extra commits show up from there.

Add mandatory/all methods to RefLike protocol.
These methods allow a RefLike implementation to determine which
dependencies are optional for a reflike, and which dependencies are
mandatory.
Also renames `include-refsets?` to `optional-deps?`.

Resolves: #77
See also: #63, #68