### PR TITLE
Add read-string-from-resource function

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,13 @@ And load it with Integrant's version of `read-string`:
   (ig/read-string (slurp "config.edn")))
 ```
 
+Or read resource from the classpath using `read-string-from-resource`:
+
+```clojure
+(def config
+  (ig/read-string-from-resource "config.edn"))
+```
+
 ### Initializing and halting
 
 Once you have a configuration, Integrant needs to be told how to

--- a/resources/config-test-1.edn
+++ b/resources/config-test-1.edn
@@ -1,0 +1,1 @@
+{:foo/a #ig/ref :foo/b, :foo/b 1}

--- a/resources/config-test-2.edn
+++ b/resources/config-test-2.edn
@@ -1,0 +1,1 @@
+{:foo/a #ig/refset :foo/b, :foo/b 1}

--- a/resources/config-test-3.edn
+++ b/resources/config-test-3.edn
@@ -1,0 +1,1 @@
+{:foo/a #test/var clojure.core/+}

--- a/src/integrant/core.cljc
+++ b/src/integrant/core.cljc
@@ -2,6 +2,7 @@
   (:refer-clojure :exclude [ref read-string run!])
   (:require #?(:clj  [clojure.edn :as edn]
                :cljs [clojure.tools.reader.edn :as edn])
+            #?(:clj  [clojure.java.io :as io])
             [clojure.walk :as walk]
             [clojure.set :as set]
             [clojure.spec.alpha :as s]
@@ -175,6 +176,12 @@
    (let [readers (merge default-readers (:readers opts {}))]
      (edn/read-string (assoc opts :readers readers) s))))
 
+#?(:clj (defn read-string-from-resource
+          "Read a config resource file placed in resources on the classpath."
+          ([file-name]
+           (read-string (slurp (io/resource file-name))))
+          ([opts file-name]
+           (read-string opts (slurp (io/resource file-name))))))
 #?(:clj
    (defn- keyword->namespaces [kw]
      (if-let [ns (namespace kw)]

--- a/test/integrant/core_test.cljc
+++ b/test/integrant/core_test.cljc
@@ -99,6 +99,16 @@
             {:foo/a #'+}))))
 
 #?(:clj
+   (deftest read-string-from-resource-test
+     (is (= (ig/read-string-from-resource "config-test-1.edn")
+            {:foo/a (ig/ref :foo/b), :foo/b 1}))
+     (is (= (ig/read-string-from-resource "config-test-2.edn")
+            {:foo/a (ig/refset :foo/b), :foo/b 1}))
+     (is (= (ig/read-string-from-resource {:readers {'test/var find-var}}
+                                          "config-test-3.edn")
+            {:foo/a #'+}))))
+
+#?(:clj
    (defn- remove-lib [lib]
      (remove-ns lib)
      (dosync (alter @#'clojure.core/*loaded-libs* disj lib))))


### PR DESCRIPTION
This commit could be trivial but I believe that configuration files could be placed in resources path normally.

and I make a `read-string-from-resource` which is using `read-string` function.

