### PR TITLE
Suppress internal deprecation warnings

### DIFF
--- a/src/integrant/core.cljc
+++ b/src/integrant/core.cljc
@@ -471,11 +471,13 @@
   Deprecated in favor of [[expand]]."
   {:deprecated "0.9.0"}
   ([config]
-   (prep config (keys config)))
+   ^:deprecation-nowarn (prep config (keys config)))
   ([config keys]
    {:pre [(map? config)]}
    (let [keyset (set keys)]
-     (reduce-kv (fn [m k v] (assoc m k (if (keyset k) (prep-key k v) v)))
+     (reduce-kv (fn [m k v] (assoc m k (if (keyset k)
+                                         ^:deprecation-nowarn (prep-key k v)
+                                         v)))
                 {} config))))
 
 (defn- converge-values [[k v]]


### PR DESCRIPTION
When using integrant in a clojurescript project (with shadow-cljs) you get deprecation warnings, even though no deprecated functions are used, because of integrant's internal usage of the deprecated functions. 

```
------ WARNING #1 - :fn-deprecated ---------------------------------------------
 Resource: integrant/core.cljc:474:4
 integrant.core/prep is deprecated
--------------------------------------------------------------------------------

------ WARNING #2 - :fn-deprecated ---------------------------------------------
 Resource: integrant/core.cljc:478:55
 integrant.core/prep-key is deprecated
--------------------------------------------------------------------------------
```

You also see them when running the node-tests:

```
~/p/integrant ❯❯❯ lein test-node
WARNING: integrant.core/prep is deprecated at line 474 /Users/david/projects/integrant/src/integrant/core.cljc
WARNING: integrant.core/prep-key is deprecated at line 478 /Users/david/projects/integrant/src/integrant/core.cljc
WARNING: integrant.core/prep is deprecated at line 236 test/integrant/core_test.cljc
WARNING: integrant.core/prep is deprecated at line 240 test/integrant/core_test.cljc
WARNING: integrant.core/prep is deprecated at line 244 test/integrant/core_test.cljc

;; ======================================================================
;; Testing with Node:


Testing integrant.core-test

Ran 20 tests containing 120 assertions.
0 failures, 0 errors.
```

This PR fixes only the warnings you see from `core` because those are the ones that affect users of integrant. I can address the warnings in `core-test` as well if you like.
